### PR TITLE
Migrate to LangChain.dart v0.6.0 and minor improvements

### DIFF
--- a/backend/pubspec.yaml
+++ b/backend/pubspec.yaml
@@ -13,36 +13,12 @@ dependencies:
   shelf_cors_headers: ^0.1.5
   dart_frog: ^1.1.0
 
-  #langchain: ^0.4.3
-  # NOTE: Using pre-release version that includes necessary bug fixes
-  langchain:
-    git:
-      url: https://github.com/davidmigloz/langchain_dart
-      path: packages/langchain
-
-  #langchain_openai: ^0.4.3
-  # NOTE: This override can be removed when updating "langchain" to a published version.
-  langchain_openai:
-    git:
-      url: https://github.com/davidmigloz/langchain_dart
-      path: packages/langchain_openai
-
-  #langchain_community: ^0.4.3
-  # NOTE: This override can be removed when updating "langchain" to a published version.
-  langchain_community:
-    git:
-      url: https://github.com/davidmigloz/langchain_dart
-      path: packages/langchain_community
+  langchain: ^0.6.0+1
+  langchain_community: ^0.1.0+2
+  langchain_openai: ^0.5.1+1
 
   shared_model:
     path: ../shared_model
-
-dependency_overrides:
-  # NOTE: Using pre-release version that includes necessary bug fixes. This override can be removed when updating "langchain" to a published version.
-  langchain_core:
-    git:
-      url: https://github.com/davidmigloz/langchain_dart
-      path: packages/langchain_core
 
 dev_dependencies:
   mocktail: ^1.0.0


### PR DESCRIPTION
Hey @tolo,

Thanks for creating this project, one of the weaknesses of LangChain.dart is that we don't have many demo projects. So this really helps 🙂

In this PR, I've migrated the project to the latest version of LangChain.dart and applied some minor improvements, specifically:
- Updated the model from `gpt-4-turbo-preview` to `gpt-4-turbo`, which is no longer in preview.
- Changed the input type of the `_setupFinalAnswerChain` from `Map<String, dynamic>` to `String` to make the chain more type safe.
- Migrated from `Runnable.fromFunction` to `Runnable.mapInput`, which requires slightly less boilerplate. 
- Shorten `(entry.content as ChatMessageContentText).text` to `entry.contentAsString`
- Change `ChatPromptTemplate.fromPromptMessages` to `ChatPromptTemplate.fromTemplate`, which requires less boilerplate
- Run `rephrasedQuestion` as part of the `answerChain` instead of separately, as since the last release the retriever will reduce the input stream to a single value, preventing the problem you encountered.

Managing the chat history when using runnables is still quite manual, unfortunately, but I plan to improve this in an upcoming release.

Let me know if you have any feedback!